### PR TITLE
Initialize FairMQ program options and provide session parameter

### DIFF
--- a/cmake/ReadoutDependencies.cmake
+++ b/cmake/ReadoutDependencies.cmake
@@ -18,7 +18,7 @@ if (FAIRROOT_FOUND)
     # this should go away when fairrot provides a proper Find script or proper config scripts
     # See : http://www.cmake.org/cmake/help/v3.0/command/link_directories.html
     link_directories(${FAIRROOT_LIBRARY_DIR})
-    set(FAIRROOT_LIBRARIES Base FairMQ BaseMQ)
+    set(FAIRROOT_LIBRARIES Base FairMQ BaseMQ Logger)
     ADD_DEFINITIONS(-DWITH_FAIRMQ)
 else (FAIRROOT_FOUND)
     message(WARNING "FairRoot not found, corresponding classes will not be compiled.")

--- a/readout.cfg
+++ b/readout.cfg
@@ -130,6 +130,8 @@ enabled=0
 # light FMQ channel implementation
 # WP5-compatible output
 [consumer-fmq-wp5]
+# session name must match --session parameter of all O2 devices in the chain
+sessionName=default
 consumerType=FairMQChannel
 enabled=0
 transportType=shmem

--- a/src/ConsumerFMQchannel.cxx
+++ b/src/ConsumerFMQchannel.cxx
@@ -63,6 +63,9 @@ class ConsumerFMQchannel: public Consumer {
       disableSending=true;
     }
     
+    std::string cfgSessionName="default";
+    cfg.getOptionalValue<std::string>(cfgEntryPoint + ".sessionName", cfgSessionName);
+
     std::string cfgTransportType="zeromq";
     cfg.getOptionalValue<std::string>(cfgEntryPoint + ".transportType", cfgTransportType);
     
@@ -75,9 +78,13 @@ class ConsumerFMQchannel: public Consumer {
     std::string cfgChannelAddress="ipc:///tmp/pipe-readout";
     cfg.getOptionalValue<std::string>(cfgEntryPoint + ".channelAddress", cfgChannelAddress);
 
+    theLog.log("Using FairMQ session name: %s", cfgSessionName.c_str());
     theLog.log("Creating FMQ TX channel %s type %s:%s @ %s",cfgChannelName.c_str(),cfgTransportType.c_str(),cfgChannelType.c_str(),cfgChannelAddress.c_str());
             
-    transportFactory=FairMQTransportFactory::CreateTransportFactory(cfgTransportType);
+    FairMQProgOptions fmqOptions;
+    fmqOptions.SetValue<std::string>("session", cfgSessionName);
+
+    transportFactory=FairMQTransportFactory::CreateTransportFactory(cfgTransportType, fair::mq::tools::Uuid(), &fmqOptions);
     sendingChannel=std::make_unique<FairMQChannel>(cfgChannelName, cfgChannelType, transportFactory);
     
     std::string cfgUnmanagedMemorySize="";


### PR DESCRIPTION
In order to properly setup the communication channels, each participant
has to be configured with the same `session` parameter. This option also
enables running multiple device chains on the same node (e.g. multiuser
environment)