### PR TITLE
Fix lookup of InfoLogger headers

### DIFF
--- a/cmake/FindInfoLogger.cmake
+++ b/cmake/FindInfoLogger.cmake
@@ -14,7 +14,7 @@
 include(FindPackageHandleStandardArgs)
 
 # find includes
-find_path(INFOLOGGER_INCLUDE_DIR InfoLogger.h
+find_path(INFOLOGGER_INCLUDE_DIR InfoLogger.hxx
         HINTS ${InfoLogger_ROOT}/include ENV LD_LIBRARY_PATH PATH_SUFFIXES "../include/InfoLogger" "../../include/InfoLogger" )
 # Remove the final "InfoLogger"
 get_filename_component(INFOLOGGER_INCLUDE_DIR ${INFOLOGGER_INCLUDE_DIR} DIRECTORY)


### PR DESCRIPTION
This is needed for [alisw/alidist#1516](https://github.com/alisw/alidist/pull/1516) to work.