### PR TITLE
Add missing header for std::string

### DIFF
--- a/src/SocketTx.hxx
+++ b/src/SocketTx.hxx
@@ -1,6 +1,7 @@
 #include <thread>
 #include <memory>
 #include <atomic>
+#include <string>
 #include <Common/Timer.h>
 
 #include <Common/DataBlock.h>


### PR DESCRIPTION
Fixes compilation on mac.