### PR TITLE
Remove boost signals (removed in boost 1.70)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # check FairMQ
 # FairMQ::FairMQ target does not provide the transitive dependency on FairLogger and Boost, so we have to add them manually
-find_package(Boost COMPONENTS container thread regex date_time signals )
+find_package(Boost COMPONENTS container thread regex date_time )
 find_package(FairLogger)
 if ((NOT FairMQ_FOUND) OR (NOT FairLogger_FOUND))
   message(STATUS "FairMQ or FairLogger not found, corresponding features disabled")


### PR DESCRIPTION
Signals break the bump to boost 1.70.
It is not used in Readout, so we can just remove it.
Could you merge asap, since this is needed for alisw/alidist#1776 ?