### PR TITLE
Add missing Uuid.h header

### DIFF
--- a/src/ConsumerFMQchannel.cxx
+++ b/src/ConsumerFMQchannel.cxx
@@ -21,6 +21,7 @@
 #include <fairmq/FairMQDevice.h>
 #include <fairmq/FairMQMessage.h>
 #include <fairmq/FairMQTransportFactory.h>
+#include <fairmq/tools/Unique.h>
 
 #include "RAWDataHeader.h"
 #include "SubTimeframe.h"


### PR DESCRIPTION
FairMQ 1.4.9 cleaned up headers so we need to adapt.