### PR TITLE
Set data size to pagesize in case of non-autoChunk

### DIFF
--- a/src/ReadoutEquipmentPlayer.cxx
+++ b/src/ReadoutEquipmentPlayer.cxx
@@ -345,6 +345,7 @@ DataBlockContainerReference ReadoutEquipmentPlayer::getNextBlock() {
     } else {
       // copy file data to page, if not done already
       if (!preLoad) {
+    	b->header.dataSize = bytesPerPage;
         copyFileDataToPage(b->data);
       }
     }


### PR DESCRIPTION
The payload size is not initialized when not running
in autoChunk mode. Setting the data size in the data
header for this mode again to bytesPerPage, as was
the behaviour in Readout < 1.2.