### PR TITLE
Replace deprecated method call

### DIFF
--- a/src/testTxFMQ.cxx
+++ b/src/testTxFMQ.cxx
@@ -25,7 +25,7 @@ int main() {
   auto channel =
       FairMQChannel{cfgChannelName, cfgChannelType, transportFactory};
   channel.Bind(cfgChannelAddress);
-  if (!channel.ValidateChannel()) {
+  if (!channel.Validate()) {
     return -1;
   }
 


### PR DESCRIPTION
The method has been deprecated since July 2019, and is removed in the latest FairMQ tag.
Needed for https://github.com/alisw/alidist/pull/2554.

Please tag Readout once this is merged, the above PR depends will depend on the new tag.