### PR TITLE
Fix possible string truncation, that triggers compiler warning

### DIFF
--- a/src/ConsumerFileRecorder.cxx
+++ b/src/ConsumerFileRecorder.cxx
@@ -263,7 +263,7 @@ class ConsumerFileRecorder : public Consumer
     std::string newFileName;
 
     // string for file incremental ID
-    char sFileId[4] = "";
+    char sFileId[11] = "";
     if ((filesMax != 1) && (fileId > 0)) {
       snprintf(sFileId, sizeof(sFileId), "%03d", fileId);
     }


### PR DESCRIPTION
@sy-c : Could you merge this and create yet another tag?
Sorry for the mess. I have tested in the CI container locally that this is the last fix that is needed at least :)