### PR TITLE
[OMON-593] Explicitly define list of process monitoring metrics

### DIFF
--- a/src/ConsumerStats.cxx
+++ b/src/ConsumerStats.cxx
@@ -266,7 +266,7 @@ class ConsumerStats : public Consumer
       int processMonitoringInterval = 0;
       cfg.getOptionalValue(cfgEntryPoint + ".processMonitoringInterval", processMonitoringInterval, 0);
       if (processMonitoringInterval > 0) {
-        monitoringCollector->enableProcessMonitoring(processMonitoringInterval);
+        monitoringCollector->enableProcessMonitoring(processMonitoringInterval, {PmMeasurement::Cpu, PmMeasurement::Mem});
       }
     }
 


### PR DESCRIPTION
This will avoid reading some counters from `/proc/self/smaps_rollup` and publishing: pss, private dirty and clean memory.