### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/ConsumerDataSampling.cxx
+++ b/src/ConsumerDataSampling.cxx
@@ -13,10 +13,10 @@
 
 #ifdef WITH_FAIRMQ
 
-#include <fairmq/FairMQDevice.h>
-#include <fairmq/FairMQMessage.h>
-#include <fairmq/FairMQParts.h>
-#include <fairmq/FairMQTransportFactory.h>
+#include <fairmq/Device.h>
+#include <fairmq/Message.h>
+#include <fairmq/Parts.h>
+#include <fairmq/TransportFactory.h>
 #include <thread>
 #include "ReadoutUtils.h"
 
@@ -91,30 +91,30 @@ class ConsumerDataSampling : public Consumer
 
     sender.fChannels = m;
     sender.SetTransport("zeromq");
-    sender.ChangeState(fair::mq::Transition::InitDevice);
+    sender.ChangeStateOrThrow(fair::mq::Transition::InitDevice);
     sender.WaitForState(fair::mq::State::InitializingDevice);
-    sender.ChangeState(fair::mq::Transition::CompleteInit);
+    sender.ChangeStateOrThrow(fair::mq::Transition::CompleteInit);
     sender.WaitForState(fair::mq::State::Initialized);
-    sender.ChangeState(fair::mq::Transition::Bind);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Bind);
     sender.WaitForState(fair::mq::State::Bound);
-    sender.ChangeState(fair::mq::Transition::Connect);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Connect);
     sender.WaitForState(fair::mq::State::DeviceReady);
-    sender.ChangeState(fair::mq::Transition::InitTask);
+    sender.ChangeStateOrThrow(fair::mq::Transition::InitTask);
     sender.WaitForState(fair::mq::State::Ready);
-    sender.ChangeState(fair::mq::Transition::Run);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Run);
 
     //    sender.InteractiveStateLoop();
   }
 
   ~ConsumerDataSampling()
   {
-    sender.ChangeState(fair::mq::Transition::Stop);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Stop);
     sender.WaitForState(fair::mq::State::Ready);
-    sender.ChangeState(fair::mq::Transition::ResetTask);
+    sender.ChangeStateOrThrow(fair::mq::Transition::ResetTask);
     sender.WaitForState(fair::mq::State::DeviceReady);
-    sender.ChangeState(fair::mq::Transition::ResetDevice);
+    sender.ChangeStateOrThrow(fair::mq::Transition::ResetDevice);
     sender.WaitForState(fair::mq::State::Idle);
-    sender.ChangeState(fair::mq::Transition::End);
+    sender.ChangeStateOrThrow(fair::mq::Transition::End);
 
     if (deviceThread.joinable()) {
       deviceThread.join();

--- a/src/ConsumerFMQ.cxx
+++ b/src/ConsumerFMQ.cxx
@@ -13,9 +13,9 @@
 
 #ifdef WITH_FAIRMQ
 
-#include <fairmq/FairMQDevice.h>
-#include <fairmq/FairMQMessage.h>
-#include <fairmq/FairMQTransportFactory.h>
+#include <fairmq/Device.h>
+#include <fairmq/Message.h>
+#include <fairmq/TransportFactory.h>
 #include <thread>
 #include "ReadoutUtils.h"
 
@@ -89,30 +89,30 @@ class ConsumerFMQ : public Consumer
 
     sender.fChannels = m;
     sender.SetTransport("zeromq");
-    sender.ChangeState(fair::mq::Transition::InitDevice);
+    sender.ChangeStateOrThrow(fair::mq::Transition::InitDevice);
     sender.WaitForState(fair::mq::State::InitializingDevice);
-    sender.ChangeState(fair::mq::Transition::CompleteInit);
+    sender.ChangeStateOrThrow(fair::mq::Transition::CompleteInit);
     sender.WaitForState(fair::mq::State::Initialized);
-    sender.ChangeState(fair::mq::Transition::Bind);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Bind);
     sender.WaitForState(fair::mq::State::Bound);
-    sender.ChangeState(fair::mq::Transition::Connect);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Connect);
     sender.WaitForState(fair::mq::State::DeviceReady);
-    sender.ChangeState(fair::mq::Transition::InitTask);
+    sender.ChangeStateOrThrow(fair::mq::Transition::InitTask);
     sender.WaitForState(fair::mq::State::Ready);
-    sender.ChangeState(fair::mq::Transition::Run);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Run);
 
     //    sender.InteractiveStateLoop();
   }
 
   ~ConsumerFMQ()
   {
-    sender.ChangeState(fair::mq::Transition::Stop);
+    sender.ChangeStateOrThrow(fair::mq::Transition::Stop);
     sender.WaitForState(fair::mq::State::Ready);
-    sender.ChangeState(fair::mq::Transition::ResetTask);
+    sender.ChangeStateOrThrow(fair::mq::Transition::ResetTask);
     sender.WaitForState(fair::mq::State::DeviceReady);
-    sender.ChangeState(fair::mq::Transition::ResetDevice);
+    sender.ChangeStateOrThrow(fair::mq::Transition::ResetDevice);
     sender.WaitForState(fair::mq::State::Idle);
-    sender.ChangeState(fair::mq::Transition::End);
+    sender.ChangeStateOrThrow(fair::mq::Transition::End);
 
     if (deviceThread.joinable()) {
       deviceThread.join();

--- a/src/readoutMemoryMonitor.cxx
+++ b/src/readoutMemoryMonitor.cxx
@@ -197,8 +197,8 @@ int main(int argc, char** argv)
               isOk = 0;
               break;
             }
-            auto stats = ((MemoryPagesPool::Stats *)msgBuffer[1+p*2]);
             unsigned int npages = msgSize[2+p*2] / sizeof(MemoryPagesPool::PageStat);
+            //auto stats = ((MemoryPagesPool::Stats *)msgBuffer[1+p*2]);
             //printf("%d %d: %f - %f - %u\n",p, stats->id, stats->t0,stats->t1,npages);
             auto ps = (MemoryPagesPool::PageStat*)msgBuffer[2+p*2];
             int c = 0;
@@ -231,7 +231,7 @@ int main(int argc, char** argv)
             SDL_Rect r = {ox,oy,cw,cy};
             SDL_RenderDrawRect(hRenderer, &r);
             
-            auto stats = ((MemoryPagesPool::Stats *)msgBuffer[1+p*2]);
+            //auto stats = ((MemoryPagesPool::Stats *)msgBuffer[1+p*2]);
             unsigned int npages = msgSize[2+p*2] / sizeof(MemoryPagesPool::PageStat);
             auto ps = (MemoryPagesPool::PageStat*)msgBuffer[2+p*2];
 
@@ -261,7 +261,7 @@ int main(int argc, char** argv)
               }
               int rx = k % npl;
               int ry = k / npl;
-              SDL_Rect r = {ox+bb+rx*pxk+1,oy+bb+ry*pxk+1,pxk-2,pxk-2};
+              SDL_Rect r = {(int)(ox+bb+rx*pxk+1),(int)(oy+bb+ry*pxk+1),(int)(pxk-2),(int)(pxk-2)};
               SDL_RenderFillRect(hRenderer, &r);
             }
           }

--- a/src/receiverFMQ.cxx
+++ b/src/receiverFMQ.cxx
@@ -582,17 +582,17 @@ int main(int argc, const char** argv)
 
   fd.fChannels = m;
   fd.SetTransport("zeromq");
-  fd.ChangeState(fair::mq::Transition::InitDevice);
+  fd.ChangeStateOrThrow(fair::mq::Transition::InitDevice);
   fd.WaitForState(fair::mq::State::InitializingDevice);
-  fd.ChangeState(fair::mq::Transition::CompleteInit);
+  fd.ChangeStateOrThrow(fair::mq::Transition::CompleteInit);
   fd.WaitForState(fair::mq::State::Initialized);
-  fd.ChangeState(fair::mq::Transition::Bind);
+  fd.ChangeStateOrThrow(fair::mq::Transition::Bind);
   fd.WaitForState(fair::mq::State::Bound);
-  fd.ChangeState(fair::mq::Transition::Connect);
+  fd.ChangeStateOrThrow(fair::mq::Transition::Connect);
   fd.WaitForState(fair::mq::State::DeviceReady);
-  fd.ChangeState(fair::mq::Transition::InitTask);
+  fd.ChangeStateOrThrow(fair::mq::Transition::InitTask);
   fd.WaitForState(fair::mq::State::Ready);
-  fd.ChangeState(fair::mq::Transition::Run);
+  fd.ChangeStateOrThrow(fair::mq::Transition::Run);
 
   //    fd.InteractiveStateLoop();
 
@@ -603,13 +603,13 @@ int main(int argc, const char** argv)
   }
   printf("Exit requested\n");
 
-  fd.ChangeState(fair::mq::Transition::Stop);
+  fd.ChangeStateOrThrow(fair::mq::Transition::Stop);
   fd.WaitForState(fair::mq::State::Ready);
-  fd.ChangeState(fair::mq::Transition::ResetTask);
+  fd.ChangeStateOrThrow(fair::mq::Transition::ResetTask);
   fd.WaitForState(fair::mq::State::DeviceReady);
-  fd.ChangeState(fair::mq::Transition::ResetDevice);
+  fd.ChangeStateOrThrow(fair::mq::Transition::ResetDevice);
   fd.WaitForState(fair::mq::State::Idle);
-  fd.ChangeState(fair::mq::Transition::End);
+  fd.ChangeStateOrThrow(fair::mq::Transition::End);
 
   printf("Done!\n");
   return 0;


### PR DESCRIPTION
This fixes compilation warnings from unused variables, deprecated includes, and narrowing conversions.

Also, the FMQ ChangeState API was changed, and requires handling of the return value. I have thus changed it to ChangeStateOrThrow, i.e. now it will fail if the state change failed, which I think is the right thing to do.
Although, before deploying, we should double-check that we do not have bogus invalid state changes, which would not crash the software.