### PR TITLE
Fix std::is_pod usage

### DIFF
--- a/src/ConsumerFMQchannel.cxx
+++ b/src/ConsumerFMQchannel.cxx
@@ -55,7 +55,7 @@ struct DataBlockFMQStats {
   uint64_t dataSizeAccounted;
   uint64_t memorySizeAccounted;
 };
-static_assert(std::is_pod<DataBlockFMQStats>::value, "DataBlockFMQStats is not a POD");
+static_assert(std::is_standard_layout_v<DataBlockFMQStats>, "DataBlockFMQStats is not a POD");
 static_assert(sizeof(DataBlockFMQStats) <= DataBlockHeaderUserSpace, "DataBlockFMQStats does not fit in DataBlock.userSpace");
 
 #define timeNowMicrosec (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch())).count

--- a/src/DataBlock.h
+++ b/src/DataBlock.h
@@ -87,8 +87,8 @@ typedef struct {
 const DataBlock defaultDataBlock = { .header = defaultDataBlockHeader, .data = nullptr };
 
 // compile-time checks
-static_assert(std::is_pod<DataBlockHeader>::value, "DataBlockHeader is not a POD");
-static_assert(std::is_pod<DataBlock>::value, "DataBlock is not a POD");
+static_assert(std::is_standard_layout_v<DataBlockHeader>, "DataBlockHeader is not a POD");
+static_assert(std::is_standard_layout_v<DataBlock>, "DataBlock is not a POD");
 
 #endif /* READOUT_DATABLOCK */
 

--- a/src/ReadoutStats.h
+++ b/src/ReadoutStats.h
@@ -60,7 +60,7 @@ struct ReadoutStatsCounters {
 const uint32_t ReadoutStatsCountersVersion = 0xA0000004;
 
 // need to be able to easily transmit this struct as a whole
-static_assert(std::is_pod<ReadoutStatsCounters>::value);
+static_assert(std::is_standard_layout<ReadoutStatsCounters>::value);
 
 // utility to assign strings to uint64
 uint64_t stringToUint64(const char*);


### PR DESCRIPTION
std::is_pod is deprecated in C++20 and it's deemed to be equivalent to std::is_standard_layout_v<T> && std::is_trivial_v<T>.

Moreover, due to the above equivalence std::is_pod_v<std::atomic<T>> is actually false (atomic are not trivial).